### PR TITLE
fix empty path

### DIFF
--- a/korlibs-io-network-core/src/korlibs/io/http/core/HttpRawFetchPortable.kt
+++ b/korlibs-io-network-core/src/korlibs/io/http/core/HttpRawFetchPortable.kt
@@ -10,7 +10,7 @@ internal fun SocketHttpFetch(socketGen: suspend (Boolean) -> AsyncSocket = { Asy
             socket.connect(host, port)
             val buffered = BufferedAsyncInputStream(socket)
 
-            socket.write(computeHeader(method, path, host, headers).encodeToByteArray())
+            socket.write(computeHeader(method, if (path.isBlank()) "/" else path, host, headers).encodeToByteArray())
             body?.copyTo(socket)
 
             val firstLine = buffered.readLine()


### PR DESCRIPTION
HTTP requests fail with a bad request error if the path is empty. If the path is empty, it can be considered as `/`

this is failing with 400 bad request
HttpFetch.fetch("GET", "google.com", 443, "", secure = true, headers = listOf())

This issue also mentioned here:
https://github.com/fleeksoft/ksoup/issues/43